### PR TITLE
Add Bitcoin constant

### DIFF
--- a/lib/Mollie/API/Object/Method.rb
+++ b/lib/Mollie/API/Object/Method.rb
@@ -8,6 +8,7 @@ module Mollie
 				BANKTRANSFER = "banktransfer"
 				PAYPAL       = "paypal"
 				PAYSAFECARD  = "paysafecard"
+				BITCOIN	     = "bitcoin"
 
 				attr_accessor :id,
 				              :description,


### PR DESCRIPTION
Using this fix the bitcoin payment method is also available

closes https://github.com/mollie/mollie-api-ruby/issues/5
