### PR TITLE
Update rest-client to a recent version

### DIFF
--- a/mollie.gemspec
+++ b/mollie.gemspec
@@ -11,9 +11,9 @@ spec = Gem::Specification.new do |s|
   s.email = ['info@mollie.nl']
   s.homepage = 'https://github.com/mollie/mollie-api-ruby'
   s.license = 'BSD'
-  s.required_ruby_version = '>= 1.9.2'
+  s.required_ruby_version = '>= 1.9.3'
 
-  s.add_dependency('rest-client', '~> 1.6')
+  s.add_dependency('rest-client', '~> 1.8')
   s.add_dependency('json', '~> 1.8')
 
   s.files = `git ls-files`.split("\n")


### PR DESCRIPTION
Closes https://github.com/mollie/mollie-api-ruby/issues/10

Since restclient had a recent vulnerability, the _mollie-api-ruby_ gem prevented it from updating to the latest version. This PR fixes the set dependency so a more recent version can be installed.

@paetor PR as requested ;)