### PR TITLE
Adds HTTP error code to raised errors

### DIFF
--- a/lib/Mollie/API/Client.rb
+++ b/lib/Mollie/API/Client.rb
@@ -73,6 +73,7 @@ module Mollie
           http_body.delete_if { |k, v| v.nil? }
         end
 
+        http_code = nil
         begin
           request_url = "#{@api_endpoint}/#{API_VERSION}/#{api_method}/#{id}".chomp "/"
           rest_client = _getRestClient request_url, request_headers
@@ -87,12 +88,14 @@ module Mollie
           end
           response = JSON.parse response, :symbolize_names => true
         rescue RestClient::ExceptionWithResponse => e
+          http_code = e.http_code
           response = JSON.parse e.response, :symbolize_names => true
           raise e if response[:error].nil?
         end
 
         unless response[:error].nil?
           exception = Mollie::API::Exception.new response[:error][:message]
+          exception.code = http_code
           exception.field = response[:error][:field] unless response[:error][:field].nil?
           raise exception
         end

--- a/lib/Mollie/API/Exception.rb
+++ b/lib/Mollie/API/Exception.rb
@@ -2,8 +2,9 @@ module Mollie
   module API
     class Exception < StandardError
       @field = nil
+      @code = nil
 
-      attr_accessor :field
+      attr_accessor :field, :code
     end
   end
 end


### PR DESCRIPTION
The API status codes are [well documented](https://www.mollie.com/en/docs/errors#alle-mogelijke-statuscodes) however the API library currently discards the status code. This change captures the HTTP code and returns it on the raised error.

Having this status available is important to allow callers to distinguish between cases such as a payment not being found, credentials being invalid, or the gateway being down.