### PR TITLE
Rubyesque aliases

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -18,7 +18,7 @@ To use the Mollie API client, the following things are required:
 By far the easiest way to install the Mollie API client is to install it with [gem](http://rubygems.org/).
 
 ```
-	$ gem install mollie-api-ruby
+$ gem install mollie-api-ruby
 ```
 
 You may also git checkout or [download all the files](https://github.com/mollie/mollie-api-ruby/archive/master.zip), and include the Mollie API client manually.
@@ -38,33 +38,33 @@ To successfully receive a payment, these steps should be implemented:
 Requiring the Mollie API Client.
 
 ```ruby
-		require "Mollie/API/Client"
+require "Mollie/API/Client"
 ```
 
 Initializing the Mollie API client, and setting your API key.
 
 ```ruby
-		mollie = Mollie::API::Client.new
-		mollie.api_key = "test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM"
+mollie = Mollie::API::Client.new
+mollie.api_key = "test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM"
 ```
 
 Creating a new payment.
 
 ```ruby
-		payment = mollie.payments.create \
-			:amount      => 10.00,
-			:description => "My first API payment",
-			:redirectUrl => "https://webshop.example.org/order/12345/"
+payment = mollie.payments.create \
+  :amount      => 10.00,
+  :description => "My first API payment",
+  :redirectUrl => "https://webshop.example.org/order/12345/"
 ```
 
 Retrieving a payment.
 
 ```ruby
-		payment = mollie.payments.get payment.id
+payment = mollie.payments.get payment.id
 
-		if payment.paid?
-			puts "Payment received."
-		end
+if payment.paid?
+  puts "Payment received."
+end
 ```
 
 ### Refunding payments ###
@@ -74,8 +74,8 @@ definitive. Refunds are only supported for iDEAL, credit card and Bank Transfer 
 be refunded through our API at the moment.
 
 ```ruby
-		payment = mollie.payments.get payment.id
-		refund  = mollie.payments_refunds.with(payment).create
+payment = mollie.payments.get payment.id
+refund  = mollie.payments_refunds.with(payment).create
 ```
 
 ## Examples ##
@@ -83,8 +83,8 @@ be refunded through our API at the moment.
 The examples require [Sinatra](http://rubygems.org/gems/sinatra) so you will need to install that gem first. Afterwards simply run:
 
 ```
-	$ cd mollie-api-ruby
-	$ ruby examples/app.rb
+$ cd mollie-api-ruby
+$ ruby examples/app.rb
 ```
 
 ## API documentation ##

--- a/README.mdown
+++ b/README.mdown
@@ -1,4 +1,4 @@
-![Mollie](http://www.mollie.nl/files/Mollie-Logo-Style-Small.png) 
+![Mollie](http://www.mollie.nl/files/Mollie-Logo-Style-Small.png)
 
 # Mollie API client for Ruby #
 
@@ -39,29 +39,29 @@ Requiring the Mollie API Client.
 
 ```ruby
 		require "Mollie/API/Client"
-```	
+```
 
 Initializing the Mollie API client, and setting your API key.
 
 ```ruby
 		mollie = Mollie::API::Client.new
-```	
 		mollie.api_key = "test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM"
+```
 
 Creating a new payment.
-	
+
 ```ruby
 		payment = mollie.payments.create \
 			:amount      => 10.00,
 			:description => "My first API payment",
 			:redirectUrl => "https://webshop.example.org/order/12345/"
 ```
-	
+
 Retrieving a payment.
 
 ```ruby
 		payment = mollie.payments.get payment.id
-		
+
 		if payment.paid?
 			puts "Payment received."
 		end

--- a/README.mdown
+++ b/README.mdown
@@ -38,32 +38,33 @@ To successfully receive a payment, these steps should be implemented:
 Requiring the Mollie API Client.
 
 ```ruby
-require "Mollie/API/Client"
+require 'Mollie/API/Client'
 ```
 
 Initializing the Mollie API client, and setting your API key.
 
 ```ruby
 mollie = Mollie::API::Client.new
-mollie.api_key = "test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM"
+mollie.api_key = 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM'
 ```
 
 Creating a new payment.
 
 ```ruby
-payment = mollie.payments.create \
-  :amount      => 10.00,
-  :description => "My first API payment",
-  :redirectUrl => "https://webshop.example.org/order/12345/"
+payment = mollie.payments.create(
+  amount: 10.00,
+  description: 'My first API payment',
+  redirectUrl: 'https://webshop.example.org/order/12345/'
+)
 ```
 
 Retrieving a payment.
 
 ```ruby
-payment = mollie.payments.get payment.id
+payment = mollie.payments.get(payment.id)
 
 if payment.paid?
-  puts "Payment received."
+  puts 'Payment received.'
 end
 ```
 
@@ -74,7 +75,7 @@ definitive. Refunds are only supported for iDEAL, credit card and Bank Transfer 
 be refunded through our API at the moment.
 
 ```ruby
-payment = mollie.payments.get payment.id
+payment = mollie.payments.get(payment.id)
 refund  = mollie.payments_refunds.with(payment).create
 ```
 

--- a/README.mdown
+++ b/README.mdown
@@ -45,8 +45,8 @@ Initializing the Mollie API client, and setting your API key.
 
 ```ruby
 		mollie = Mollie::API::Client.new
-		mollie.setApiKey "test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM"
 ```	
+		mollie.api_key = "test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM"
 
 Creating a new payment.
 	

--- a/lib/Mollie/API/Client.rb
+++ b/lib/Mollie/API/Client.rb
@@ -50,6 +50,8 @@ module Mollie
         @api_key = api_key
       end
 
+      alias_method :api_key=, :setApiKey
+
       def addVersionString(version_string)
         @version_strings << (version_string.gsub /\s+/, "-")
       end

--- a/lib/Mollie/API/Client.rb
+++ b/lib/Mollie/API/Client.rb
@@ -42,9 +42,13 @@ module Mollie
         @api_endpoint = api_endpoint.chomp "/"
       end
 
+      alias_method :api_endpoint=, :setApiEndpoint
+
       def getApiEndpoint
         @api_endpoint
       end
+
+      alias_method :api_endpoint, :getApiEndpoint
 
       def setApiKey(api_key)
         @api_key = api_key

--- a/lib/Mollie/API/Object/Payment.rb
+++ b/lib/Mollie/API/Object/Payment.rb
@@ -29,7 +29,7 @@ module Mollie
         def cancelled?
           @status == STATUS_CANCELLED
         end
-        
+
         def expired?
           @status == STATUS_EXPIRED
         end
@@ -37,7 +37,7 @@ module Mollie
         def paid?
           !@paidDatetime.nil?
         end
-        
+
         def paidout?
           @status == STATUS_PAIDOUT
         end

--- a/lib/Mollie/API/Object/Payment.rb
+++ b/lib/Mollie/API/Object/Payment.rb
@@ -45,6 +45,8 @@ module Mollie
         def getPaymentUrl
           @links && @links.paymentUrl
         end
+
+        alias_method :payment_url, :getPaymentUrl
       end
     end
   end


### PR DESCRIPTION
Following issue #16, this adds a couple of Rubyesque method aliases to `Mollie::API::Client` and `Mollie::API::Object::Payment`. 

I also took the liberty of updating the README by using Ruby Style Guide conventions in the code examples. Reason for doing this is to help other Ruby developers understand the API client code more easily.

Some suggestions for future improvements (not included in this PR, only noticed while working on it):

* Start writing automated unit and feature tests using either [RSpec](http://rspec.info/) or [minitest](https://github.com/seattlerb/minitest) (both have pros and cons). Having a test suite is something Ruby developers generally consider as a necessity nowadays.
* Include an automatic code style checker, such as [RuboCop](https://github.com/bbatsov/rubocop). This ensures everyone sticks to the same standards.
* Once you have the above, try using a CI service such as [Travis](https://travis-ci.org/) for automatically running tests and code style checks on every `git push` to a PR or `master`. Travis is free for open source projects. Added benefit is being able to test the API code against multiple Ruby versions.

To be clear: the above points are not meant as criticism, they are just suggestions based on my experiences working on other Ruby projects. If you'd like to know more about these topics, it's probably better to discuss this outside this PR.