### PR TITLE
Improve README (setApiKey)

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -45,7 +45,7 @@ Initializing the Mollie API client, and setting your API key.
 
 ```ruby
 mollie = Mollie::API::Client.new
-mollie.api_key = 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM'
+mollie.setApiKey 'test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM'
 ```
 
 Creating a new payment.


### PR DESCRIPTION
Update the method that sets the API key. 

```ruby
mollie.api_key = "abc"
# => NoMethodError: undefined method `api_key=' for #<Mollie::API::Client:0x007fbd4c3f4808>
```

There is an alias present, but that doesn't seem to work properly: [Client.rb#L64:L68](https://github.com/mollie/mollie-api-ruby/blob/9637cfb1e4f9d245ad6c1d28fc50a2ef733e739e/lib/Mollie/API/Client.rb#L64:L68)