### PR TITLE
Remove JSON dependency

### DIFF
--- a/mollie.gemspec
+++ b/mollie.gemspec
@@ -14,7 +14,6 @@ spec = Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
 
   s.add_dependency('rest-client', '~> 1.8')
-  s.add_dependency('json', '~> 1.8')
 
   s.files = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- test/*`.split("\n")


### PR DESCRIPTION
All Ruby versions >= 1.9.3 include the JSON gem in the standard library, so this requirement is redundant. See rails/rails#23453

Also: Ruby 2.4 will be bundled with a ~> 2.0 version of JSON for compatibility with the unification of Fixnum and Bignum into Integer.