### PR TITLE
Add dependency for mime-types v <3

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -11,7 +11,7 @@ To use the Mollie API client, the following things are required:
 + Create a new [Website profile](https://www.mollie.nl/beheer/account/profielen/) to generate API keys (live and test mode) and setup your webhook.
 + Now you're ready to use the Mollie API client in test mode.
 + In order to accept payments in live mode, payment methods must be activated in your account. Follow [a few of steps](https://www.mollie.nl/beheer/diensten), and let us handle the rest.
-+ This API client requires the [REST Client](https://github.com/rest-client/rest-client) and [JSON](https://rubygems.org/gems/json) gems.
++ This API client requires the [REST Client](https://github.com/rest-client/rest-client) (with [mime-types](https://github.com/mime-types/ruby-mime-types/) version <3) and  [JSON](https://rubygems.org/gems/json) gems.
 
 ## Installation ##
 

--- a/mollie.gemspec
+++ b/mollie.gemspec
@@ -15,6 +15,7 @@ spec = Gem::Specification.new do |s|
 
   s.add_dependency('rest-client', '~> 1.8')
   s.add_dependency('json', '~> 1.8')
+  s.add_dependency('mime-types', '< 3')
 
   s.files = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- test/*`.split("\n")


### PR DESCRIPTION
After installing the mollie-api-ruby gem I was not able to use the API, due to an "undefined method `[]' for #<Set: {#<MIME::Type: application/json>}>" error. I found out it was because of my version of mime-types (3.1).

This fix forces the use of mime-types < v3

See also: https://twitter.com/RogiervdBerg/status/768184731284414466

Version 2.99 of mime-types is still supported as 2.99.x, receiving quarterly updates of the IANA registry and security updates for two years. It will reach full end of life on 2017-11-21.