### PR TITLE
Update rest-client, remove json

### DIFF
--- a/mollie.gemspec
+++ b/mollie.gemspec
@@ -1,12 +1,16 @@
-$:.unshift(File.join(File.dirname(__FILE__), 'lib'))
+$:.push File.expand_path('../lib', __FILE__)
 
 require 'Mollie/API/Client/Version'
 
-spec = Gem::Specification.new do |s|
+Gem::Specification.new do |s|
   s.name = 'mollie-api-ruby'
   s.version = Mollie::API::Client::CLIENT_VERSION
   s.summary = 'Official Mollie API Client for Ruby'
-  s.description = 'Accepting iDEAL, Bancontact/Mister Cash, SOFORT Banking, Creditcard, SEPA Bank transfer, SEPA Direct debit, Bitcoin, PayPal, Belfius Direct Net, paysafecard and PODIUM Cadeaukaart online payments without fixed monthly costs or any punishing registration procedures.'
+  s.description = %(Accepting iDEAL, Bancontact/Mister Cash, SOFORT Banking,
+                  Creditcard, SEPA Bank transfer, SEPA Direct debit, Bitcoin,
+                  PayPal, Belfius Direct Net, paysafecard and PODIUM Cadeaukaart
+                  online payments without fixed monthly costs or any punishing
+                  registration procedures.')
   s.authors = ['Rick Wong']
   s.email = ['info@mollie.nl']
   s.homepage = 'https://github.com/mollie/mollie-api-ruby'
@@ -17,7 +21,5 @@ spec = Gem::Specification.new do |s|
   s.add_dependency('json', '~> 1.8')
 
   s.files = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- test/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  s.require_paths = ['lib']
+  s.test_files = Dir['test/**/*']
 end

--- a/mollie.gemspec
+++ b/mollie.gemspec
@@ -17,8 +17,7 @@ Gem::Specification.new do |s|
   s.license = 'BSD'
   s.required_ruby_version = '>= 2.0'
 
-  s.add_dependency('rest-client', '~> 1.8')
-  s.add_dependency('json', '~> 1.8')
+  s.add_dependency('rest-client', '~> 2.0')
 
   s.files = `git ls-files`.split("\n")
   s.test_files = Dir['test/**/*']

--- a/mollie.gemspec
+++ b/mollie.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.0'
 
   s.add_dependency('rest-client', '~> 2.0')
+  s.add_dependency('json', '~> 1.8')
 
   s.files = `git ls-files`.split("\n")
   s.test_files = Dir['test/**/*']

--- a/mollie.gemspec
+++ b/mollie.gemspec
@@ -15,10 +15,9 @@ Gem::Specification.new do |s|
   s.email = ['info@mollie.nl']
   s.homepage = 'https://github.com/mollie/mollie-api-ruby'
   s.license = 'BSD'
-  s.required_ruby_version = '>= 2.0'
+  s.required_ruby_version = '>= 2.1.10'
 
   s.add_dependency('rest-client', '~> 2.0')
-  s.add_dependency('json', '~> 1.8')
 
   s.files = `git ls-files`.split("\n")
   s.test_files = Dir['test/**/*']

--- a/mollie.gemspec
+++ b/mollie.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.email = ['info@mollie.nl']
   s.homepage = 'https://github.com/mollie/mollie-api-ruby'
   s.license = 'BSD'
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.0'
 
   s.add_dependency('rest-client', '~> 1.8')
   s.add_dependency('json', '~> 1.8')


### PR DESCRIPTION
The version of rest-client required by this library is old and it therefor causes version compatibility issues. This updates it to the recent 2.0 version and fixes #30.

From #29 I understand that JSON 1.8 is required. JSON 1.8.1 is included in Ruby 2.1.10 stdlib, which is currently the oldest supported Ruby version that still receives security updates. Anyone really shouldn't be using an older Ruby version in production, so I set the required Ruby version  to >= 2.1.10. This also makes #30 kind of redundant 😐