### PR TITLE
allow setting a custom user agent

### DIFF
--- a/lib/mollie/api/client.rb
+++ b/lib/mollie/api/client.rb
@@ -36,7 +36,7 @@ module Mollie
                   :customers, :customers_payments, :customers_mandates, :customers_subscriptions,
                   :api_endpoint
 
-      def initialize(api_key)
+      def initialize(api_key, options = {})
         @payments                = Mollie::API::Resource::Payments.new self
         @issuers                 = Mollie::API::Resource::Issuers.new self
         @methods                 = Mollie::API::Resource::Methods.new self
@@ -48,6 +48,7 @@ module Mollie
 
         @api_endpoint    = API_ENDPOINT
         @api_key         = api_key
+        @options         = options
         @version_strings = []
 
         add_version_string "Mollie/" << VERSION
@@ -80,7 +81,7 @@ module Mollie
 
         request['Accept']        = 'application/json'
         request['Authorization'] = "Bearer #{@api_key}"
-        request['User-Agent']    = @version_strings.join(" ")
+        request['User-Agent']    = @options[:user_agent] ? @options[:user_agent] : @version_strings.join(" ")
 
         begin
           response = client.request(request)

--- a/test/mollie/api/client_test.rb
+++ b/test/mollie/api/client_test.rb
@@ -28,10 +28,21 @@ module Mollie
 
       def test_perform_http_call_defaults
         stub_request(:any, "https://api.mollie.nl/v1/my-method")
-            .with(:headers => { 'Accept'          => 'application/json',
-                                'Authorization'   => 'Bearer test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM',
-                                'User-Agent'      => /^Mollie\/#{Mollie::API::Client::VERSION} Ruby\/#{RUBY_VERSION} OpenSSL\/.*$/ })
+            .with(:headers => { 'Accept'        => 'application/json',
+                                'Authorization' => 'Bearer test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM',
+                                'User-Agent'    => /^Mollie\/#{Mollie::API::Client::VERSION} Ruby\/#{RUBY_VERSION} OpenSSL\/.*$/ })
             .to_return(:status => 200, :body => "{}", :headers => {})
+        client.perform_http_call("GET", "my-method", nil, {})
+      end
+
+      def test_set_custom_user_agent
+        stub_request(:any, "https://api.mollie.nl/v1/my-method")
+            .with(:headers => { 'Accept'        => 'application/json',
+                                'Authorization' => 'Bearer test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM',
+                                'User-Agent'    => "My User-Agent" })
+            .to_return(:status => 200, :body => "{}", :headers => {})
+
+        client = Client.new("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM", user_agent: 'My User-Agent')
         client.perform_http_call("GET", "my-method", nil, {})
       end
 
@@ -86,7 +97,7 @@ module Mollie
           {"error": {"message": "Error on field", "field": "my-field"}}
         JSON
         stub_request(:post, "https://api.mollie.nl/v1/my-method")
-                    .to_return(:status => 500, :body => response, :headers => {})
+            .to_return(:status => 500, :body => response, :headers => {})
 
         e = assert_raise Mollie::API::Exception.new("Error on field") do
           client.perform_http_call("POST", "my-method", nil, {})


### PR DESCRIPTION
So the standard is sending the user agent like before, but allowing developers to easily set their own User-Agent.

The reason behind this is that sharing version information can be harmful. Known vulnerabilities for specific versions are easily exploited on servers that expose version info.

Please note that this library is just for developers ease, one can always write their own library. Also the uname function can be monkey patched as well. Therefor you can't always enforce the correct User-Agent to be set.
