### PR TITLE
Add limit & offset to all method

### DIFF
--- a/lib/mollie/api/client.rb
+++ b/lib/mollie/api/client.rb
@@ -63,8 +63,10 @@ module Mollie
         @version_strings << (version_string.gsub /\s+/, "-")
       end
 
-      def perform_http_call(http_method, api_method, id = nil, http_body = {})
+      def perform_http_call(http_method, api_method, id = nil, http_body = {}, query = {})
         path = "/#{API_VERSION}/#{api_method}/#{id}".chomp('/')
+        path += "?#{URI.encode_www_form(query)}" if query.length > 0
+
         case http_method
           when 'GET'
             request = Net::HTTP::Get.new(path)

--- a/lib/mollie/api/resource/base.rb
+++ b/lib/mollie/api/resource/base.rb
@@ -32,8 +32,8 @@ module Mollie
           request "DELETE", id, {}
         end
 
-        def all
-          request("GET", nil, {}) { |response|
+        def all(offset = 0, limit = 50)
+          request("GET", nil, {}, { offset: offset, count: limit }) { |response|
             Object::List.new response, resource_object
           }
         end
@@ -42,8 +42,8 @@ module Mollie
           resource_object.new response
         end
 
-        def request(method, id = 0, data = {})
-          response = @client.perform_http_call method, resource_name, id, data
+        def request(method, id = 0, data = {}, query = {})
+          response = @client.perform_http_call method, resource_name, id, data, query
 
           yield(response) if block_given?
         end

--- a/test/mollie/api/resource/base_test.rb
+++ b/test/mollie/api/resource/base_test.rb
@@ -68,7 +68,7 @@ module Mollie
         end
 
         def test_all
-          stub_request(:get, "https://api.mollie.nl/v1/testresource")
+          stub_request(:get, "https://api.mollie.nl/v1/testresource?count=50&offset=0")
               .to_return(:status => 200, :body => %{{"data":[{"id":"my-id"}]}}, :headers => {})
 
           client        = Client.new("test_dHar4XY7LxsDOtmnkVtjNVWXLSlXsM")


### PR DESCRIPTION
Currently there is no way of setting an offset and a limit when retrieving all records. This add the offset and limit query params to the all method.