### PR TITLE
Expose the failed status for a payment.

### DIFF
--- a/lib/mollie/api/object/payment.rb
+++ b/lib/mollie/api/object/payment.rb
@@ -62,6 +62,10 @@ module Mollie
           status == STATUS_REFUNDED
         end
 
+        def failed?
+          status == STATUS_FAILED
+        end
+
         def details=(details)
           @details = OpenStruct.new(details) if details.is_a?(Hash)
         end

--- a/lib/mollie/api/object/payment.rb
+++ b/lib/mollie/api/object/payment.rb
@@ -2,13 +2,15 @@ module Mollie
   module API
     module Object
       class Payment < Base
-        STATUS_OPEN      = "open"
-        STATUS_CANCELLED = "cancelled"
-        STATUS_EXPIRED   = "expired"
-        STATUS_PAID      = "paid"
-        STATUS_PAIDOUT   = "paidout"
-        STATUS_FAILED    = "failed"
-        STATUS_REFUNDED  = "refunded"
+        STATUS_OPEN         = "open"
+        STATUS_CANCELLED    = "cancelled"
+        STATUS_EXPIRED      = "expired"
+        STATUS_PAID         = "paid"
+        STATUS_PAIDOUT      = "paidout"
+        STATUS_FAILED       = "failed"
+        STATUS_REFUNDED     = "refunded"
+        STATUS_PENDING      = "pending"
+        STATUS_CHARGED_BACK = "charged_back"
 
         RECURRINGTYPE_NONE      = nil
         RECURRINGTYPE_FIRST     = "first"
@@ -64,6 +66,14 @@ module Mollie
 
         def failed?
           status == STATUS_FAILED
+        end
+
+        def pending?
+          status == STATUS_PENDING
+        end
+
+        def charged_back?
+          status == STATUS_CHARGED_BACK
         end
 
         def details=(details)

--- a/test/mollie/api/object/payment_test.rb
+++ b/test/mollie/api/object/payment_test.rb
@@ -88,7 +88,17 @@ module Mollie
 
         def test_status_failed
           assert Payment.new(status: Payment::STATUS_FAILED).failed?
-          assert !Payment.new(status: Payment::STATUS_OPEN).failed?
+          assert !Payment.new(status: 'not-failed').failed?
+        end
+
+        def test_status_pending
+          assert Payment.new(status: Payment::STATUS_PENDING).pending?
+          assert !Payment.new(status: 'not-pending').pending?
+        end
+
+        def test_status_charged_back
+          assert Payment.new(status: Payment::STATUS_CHARGED_BACK).charged_back?
+          assert !Payment.new(status: 'not-charged-back').charged_back?
         end
       end
     end

--- a/test/mollie/api/object/payment_test.rb
+++ b/test/mollie/api/object/payment_test.rb
@@ -85,6 +85,11 @@ module Mollie
           assert Payment.new(paid_datetime: Time.now).paid?
           assert !Payment.new(paid_datetime: nil).paid?
         end
+
+        def test_status_failed
+          assert Payment.new(status: Payment::STATUS_FAILED).failed?
+          assert !Payment.new(status: Payment::STATUS_OPEN).failed?
+        end
       end
     end
   end


### PR DESCRIPTION
Allow for users to call
```Ruby 
payment.failed?
payment.pending?
payment.charged_back?
```
Instead of actually having to check the status.