### PR TITLE
Rescue nil registration datetime

### DIFF
--- a/lib/mollie/api/object/organization.rb
+++ b/lib/mollie/api/object/organization.rb
@@ -16,7 +16,7 @@ module Mollie
                       :verified_datetime
 
         def registration_datetime=(registration_datetime)
-          @registration_datetime = Time.parse(registration_datetime.to_s)
+          @registration_datetime = Time.parse(registration_datetime.to_s) rescue nil
         end
 
         def verified_datetime=(verified_datetime)


### PR DESCRIPTION
It seems the organization registration datetime can be nil. I don't know what exactly causes it but not controlling this situation during the parsing phase is breaking the code.