### PR TITLE
Pass "options" array to retrieval methods

### DIFF
--- a/lib/mollie/api/resource/base.rb
+++ b/lib/mollie/api/resource/base.rb
@@ -32,8 +32,8 @@ module Mollie
           request "DELETE", id, {}
         end
 
-        def all(offset = 0, limit = 50)
-          request("GET", nil, {}, { offset: offset, count: limit }) { |response|
+        def all(offset = 0, limit = 50, options = {})
+          request("GET", nil, {}, { offset: offset, count: limit }.merge(options)) { |response|
             Object::List.new response, resource_object
           }
         end

--- a/lib/mollie/api/resource/base.rb
+++ b/lib/mollie/api/resource/base.rb
@@ -16,8 +16,8 @@ module Mollie
           }
         end
 
-        def get(id)
-          request("GET", id, {}) { |response|
+        def get(id, options = {})
+          request("GET", id, {}, options) { |response|
             new_resource_object response
           }
         end


### PR DESCRIPTION
The `get` and `list` endpoints for payments accepts extra query strings to indicate if the payment was created in testmode or not. Also OAuth authorizations may need to filter by profileID.

- https://www.mollie.com/en/docs/reference/payments/get#pfp-params
- https://www.mollie.com/en/docs/reference/payments/list#pfp-params