### PR TITLE
Add image and resource accessors to Mollie::API::Object::Issuer

### DIFF
--- a/lib/mollie/api/object/issuer.rb
+++ b/lib/mollie/api/object/issuer.rb
@@ -2,7 +2,7 @@ module Mollie
   module API
     module Object
       class Issuer < Base
-        attr_accessor :id, :name, :method
+        attr_accessor :id, :name, :method, :image, :resource
       end
     end
   end


### PR DESCRIPTION
I expected these attributes to be available on the Issuer object directly which is more in line with the JSON response.