### PR TITLE
Add issuers attr_accessor

### DIFF
--- a/lib/mollie/method.rb
+++ b/lib/mollie/method.rb
@@ -18,7 +18,8 @@ module Mollie
     attr_accessor :id,
                   :description,
                   :amount,
-                  :image
+                  :image,
+                  :issuers
 
     def normal_image
       image['normal']


### PR DESCRIPTION
It's possible to get a list of available payment methods by passing the `include` option:

```ruby
methods = ::Mollie::Method.all(
    api_key: get_preference(:api_key),
    include: 'issuers'
)
```

We currently don't allow accessing `methods.issuers` since it's missing from the `attr_accessor`.