### PR TITLE
Mollie::RequestError should inherit from Mollie::Exception

### DIFF
--- a/lib/mollie/exception.rb
+++ b/lib/mollie/exception.rb
@@ -2,7 +2,7 @@ module Mollie
   class Exception < StandardError
   end
 
-  class RequestError < RuntimeError
+  class RequestError < Mollie::Exception
     attr_accessor :status, :title, :detail, :field, :links
 
     def initialize(error)


### PR DESCRIPTION
closes: mollie/mollie-api-ruby#90