### PR TITLE
Raise specific exception when resource does not exist

### DIFF
--- a/lib/mollie/client.rb
+++ b/lib/mollie/client.rb
@@ -119,6 +119,10 @@ module Mollie
         Util.nested_underscore_keys(JSON.parse(response.body))
       when 204
         {} # No Content
+      when 404
+        json = JSON.parse(response.body)
+        exception = ResourceNotFoundError.new(json)
+        raise exception
       else
         json = JSON.parse(response.body)
         exception = Mollie::RequestError.new(json)

--- a/lib/mollie/exception.rb
+++ b/lib/mollie/exception.rb
@@ -17,4 +17,7 @@ module Mollie
       "#{status} #{title}: #{detail}"
     end
   end
+
+  class ResourceNotFoundError < RequestError
+  end
 end

--- a/test/mollie/client_test.rb
+++ b/test/mollie/client_test.rb
@@ -135,5 +135,35 @@ module Mollie
       assert_equal(json['field'],  e.field)
       assert_equal(json['_links'], e.links)
     end
+
+    def test_404_response
+      response = <<-JSON
+      {
+        "status": 404,
+        "title": "Not Found",
+        "detail": "No payment exists with token tr_WDqYK6vllg.",
+        "_links": {
+          "documentation": {
+            "href": "https://docs.mollie.com/guides/handling-errors",
+            "type": "text/html"
+          }
+        }
+      }
+      JSON
+
+      json = JSON.parse(response)
+      stub_request(:post, 'https://api.mollie.com/v2/my-method')
+        .to_return(status: 404, body: response, headers: {})
+
+      e = assert_raise ResourceNotFoundError.new(JSON.parse(response)) do
+        client.perform_http_call('POST', 'my-method', nil, {})
+      end
+
+      assert_equal(json['status'], e.status)
+      assert_equal(json['title'],  e.title)
+      assert_equal(json['detail'], e.detail)
+      assert_equal(json['field'],  e.field)
+      assert_equal(json['_links'], e.links)
+    end
   end
 end


### PR DESCRIPTION
This makes it easier to solely rescue 404s. Resolves #128.