### PR TITLE
Fix `Capture#shipment` API call

### DIFF
--- a/lib/mollie/payment/capture.rb
+++ b/lib/mollie/payment/capture.rb
@@ -30,8 +30,9 @@ module Mollie
       end
 
       def shipment(options = {})
-        return if shipment_id.nil?
-        Order::Shipment.get(shipment_id, options)
+        resource_url = Util.extract_url(links, 'shipment')
+        response = Client.instance.perform_http_call('GET', resource_url, nil, {}, options)
+        Order::Shipment.new(response)
       end
 
       def settlement(options = {})

--- a/test/mollie/payment/capture_test.rb
+++ b/test/mollie/payment/capture_test.rb
@@ -53,7 +53,7 @@ module Mollie
         stub_request(:get, 'https://api.mollie.com/v2/payments/tr_WDqYK6vllg/captures/cpt_4qqhO89gsT')
           .to_return(status: 200, body: GET_CAPTURE, headers: {})
 
-        stub_request(:get, 'https://api.mollie.com/v2/shipments/shp_3wmsgCJN4U')
+        stub_request(:get, 'https://api.mollie.com/v2/orders/ord_8wmqcHMN4U/shipments/shp_3wmsgCJN4U')
           .to_return(status: 200, body: SHIPMENT_STUB, headers: {})
 
         capture = Payment::Capture.get('cpt_4qqhO89gsT', payment_id: 'tr_WDqYK6vllg')


### PR DESCRIPTION
Fetch the Shipment resource using the hal+json `_links` href.

Resolves #106