### PR TITLE
Fix onboarding dashboard URL.

### DIFF
--- a/lib/mollie/onboarding.rb
+++ b/lib/mollie/onboarding.rb
@@ -20,7 +20,7 @@ module Mollie
     end
 
     def dashboard
-      Util.extract_url(links, 'onboarding')
+      Util.extract_url(links, 'dashboard')
     end
 
     def organization(options = {})

--- a/test/fixtures/onboarding/me.json
+++ b/test/fixtures/onboarding/me.json
@@ -10,7 +10,7 @@
             "href": "https://api.mollie.com/v2/onboarding/me",
             "type": "application/hal+json"
         },
-        "onboarding": {
+        "dashboard": {
             "href": "https://www.mollie.com/dashboard/onboarding",
             "type": "text/html"
         },


### PR DESCRIPTION
This fixes the dashboard URL for onboarding, which should be `dashboard`, not `onboarding`.