### PR TITLE
fix: Include parent resource in pagination calls

### DIFF
--- a/lib/mollie/list.rb
+++ b/lib/mollie/list.rb
@@ -38,7 +38,8 @@ module Mollie
       href = URI.parse(links['next']['href'])
       query = URI.decode_www_form(href.query).to_h
 
-      klass.all(options.merge(query))
+      response = Mollie::Client.instance.perform_http_call('GET', links['next']['href'], nil, {}, options.merge(query))
+      self.class.new(response, klass)
     end
 
     def previous(options = {})
@@ -47,7 +48,8 @@ module Mollie
       href = URI.parse(links['previous']['href'])
       query = URI.decode_www_form(href.query).to_h
 
-      klass.all(options.merge(query))
+      response = Mollie::Client.instance.perform_http_call('GET', links['previous']['href'], nil, {}, options.merge(query))
+      self.class.new(response, klass)
     end
   end
 end

--- a/test/fixtures/customer/get.json
+++ b/test/fixtures/customer/get.json
@@ -1,0 +1,36 @@
+{
+    "resource": "customer",
+    "id": "cst_8wmqcHMN4U",
+    "mode": "test",
+    "name": "Customer A",
+    "email": "customer@example.org",
+    "locale": "nl_NL",
+    "metadata": null,
+    "createdAt": "2018-04-06T13:23:21.0Z",
+    "_links": {
+        "self": {
+            "href": "https://api.mollie.com/v2/customers/cst_8wmqcHMN4U",
+            "type": "application/hal+json"
+        },
+        "dashboard": {
+            "href": "https://www.mollie.com/dashboard/org_123456789/customers/cst_8wmqcHMN4U",
+            "type": "text/html"
+        },
+        "mandates": {
+            "href": "https://api.mollie.com/v2/customers/cst_8wmqcHMN4U/mandates",
+            "type": "application/hal+json"
+        },
+        "subscriptions": {
+            "href": "https://api.mollie.com/v2/customers/cst_8wmqcHMN4U/subscriptions",
+            "type": "application/hal+json"
+        },
+        "payments": {
+            "href": "https://api.mollie.com/v2/customers/cst_8wmqcHMN4U/payments",
+            "type": "application/hal+json"
+        },
+        "documentation": {
+            "href": "https://docs.mollie.com/reference/v2/customers-api/get-customer",
+            "type": "text/html"
+        }
+    }
+}

--- a/test/fixtures/customer/list-payments-next.json
+++ b/test/fixtures/customer/list-payments-next.json
@@ -1,0 +1,30 @@
+{
+    "count": 2,
+    "_embedded": {
+        "payments": [
+            {
+                "resource": "payment",
+                "id":"tr_3"
+            },
+            {
+                "resource": "payment",
+                "id":"tr_4"
+            }
+        ]
+    },
+    "_links": {
+        "documentation": {
+            "href": "https://docs.mollie.com/reference/v2/customers-api/list-customer-payments",
+            "type": "text/html"
+        },
+        "self": {
+            "href": "https://api.mollie.com/v2/customers/cst_8wmqcHMN4U/payments?from=tr_3&limit=2",
+            "type": "application/hal+json"
+        },
+        "previous": {
+            "href": "https://api.mollie.com/v2/customers/cst_8wmqcHMN4U/payments?from=tr_1&limit=2",
+            "type": "application/hal+json"
+        },
+        "next": null
+    }
+}

--- a/test/fixtures/customer/list-payments.json
+++ b/test/fixtures/customer/list-payments.json
@@ -1,0 +1,30 @@
+{
+    "count": 2,
+    "_embedded": {
+        "payments": [
+            {
+                "resource": "payment",
+                "id":"tr_1"
+            },
+            {
+                "resource": "payment",
+                "id":"tr_2"
+            }
+        ]
+    },
+    "_links": {
+        "documentation": {
+            "href": "https://docs.mollie.com/reference/v2/customers-api/list-customer-payments",
+            "type": "text/html"
+        },
+        "self": {
+            "href": "https://api.mollie.com/v2/customers/cst_8wmqcHMN4U/payments?limit=2",
+            "type": "application/hal+json"
+        },
+        "previous": null,
+        "next": {
+            "href": "https://api.mollie.com/v2/customers/cst_8wmqcHMN4U/payments?from=tr_3&limit=2",
+            "type": "application/hal+json"
+        }
+    }
+}


### PR DESCRIPTION
Use the next and previous `_links` in the pagination logic.

Previously, pagination calls to a nested resource were incorrectly scoped.
For, example:

    payments = customer.payments(limit: 2)
    payments.next

The first line correctly retrieves:

    /v2/customers/cst_8wmqcHMN4U/payments?from=tr_3&limit=2

The second line incorrectly called:

    /v2/payments?from=tr_3&limit=2 (customer scope omitted)

Resolves #144