### PR TITLE
Add "List all payment methods" API

### DIFF
--- a/lib/mollie/method.rb
+++ b/lib/mollie/method.rb
@@ -28,6 +28,11 @@ module Mollie
                   :pricing,
                   :status
 
+    def self.all_available(options = {})
+      response = Client.instance.perform_http_call("GET", "methods", "all", {}, options)
+      Mollie::List.new(response, Mollie::Method)
+    end
+
     def minimum_amount=(minimum_amount)
       @minimum_amount = Mollie::Amount.new(minimum_amount)
     end

--- a/test/fixtures/methods/all.json
+++ b/test/fixtures/methods/all.json
@@ -1,0 +1,92 @@
+{
+    "count": 3,
+    "_embedded": {
+        "methods": [
+            {
+                "resource": "method",
+                "id": "ideal",
+                "description": "iDEAL",
+                "minimumAmount": {
+                    "value": "0.01",
+                    "currency": "EUR"
+                },
+                "maximumAmount": {
+                    "value": "50000.00",
+                    "currency": "EUR"
+                },
+                "image": {
+                    "size1x": "https://www.mollie.com/external/icons/payment-methods/ideal.png",
+                    "size2x": "https://www.mollie.com/external/icons/payment-methods/ideal%402x.png",
+                    "svg": "https://www.mollie.com/external/icons/payment-methods/ideal.svg"
+                },
+                "status": "pending-boarding",
+                "_links": {
+                    "self": {
+                        "href": "https://api.mollie.com/v2/methods/ideal",
+                        "type": "application/hal+json"
+                    }
+                }
+            },
+            {
+                "resource": "method",
+                "id": "creditcard",
+                "description": "Credit card",
+                "minimumAmount": {
+                    "value": "0.01",
+                    "currency": "EUR"
+                },
+                "maximumAmount": {
+                    "value": "2000.00",
+                    "currency": "EUR"
+                },
+                "image": {
+                    "size1x": "https://www.mollie.com/external/icons/payment-methods/creditcard.png",
+                    "size2x": "https://www.mollie.com/external/icons/payment-methods/creditcard%402x.png",
+                    "svg": "https://www.mollie.com/external/icons/payment-methods/creditcard.svg"
+                },
+                "status": "pending-boarding",
+                "_links": {
+                    "self": {
+                        "href": "https://api.mollie.com/v2/methods/creditcard",
+                        "type": "application/hal+json"
+                    }
+                }
+            },
+            {
+                "resource": "method",
+                "id": "bancontact",
+                "description": "Bancontact",
+                "minimumAmount": {
+                    "value": "0.02",
+                    "currency": "EUR"
+                },
+                "maximumAmount": {
+                    "value": "50000.00",
+                    "currency": "EUR"
+                },
+                "image": {
+                    "size1x": "https://www.mollie.com/external/icons/payment-methods/bancontact.png",
+                    "size2x": "https://www.mollie.com/external/icons/payment-methods/bancontact%402x.png",
+                    "svg": "https://www.mollie.com/external/icons/payment-methods/bancontact.svg"
+                },
+                "status": null,
+                "_links": {
+                    "self": {
+                        "href": "https://api.mollie.com/v2/methods/bancontact",
+                        "type": "application/hal+json"
+                    }
+                }
+            }
+        ]
+    },
+    "_links": {
+        "documentation": {
+            "href": "https://docs.mollie.com/reference/v2/methods-api/list-all-methods",
+            "type": "text/html"
+        },
+        "self": {
+            "href": "https://api.mollie.com/v2/methods/all",
+            "type": "application/hal+json"
+        }
+    }
+}

--- a/test/mollie/method_test.rb
+++ b/test/mollie/method_test.rb
@@ -30,6 +30,17 @@ module Mollie
       assert_equal 'https://www.mollie.com/external/icons/payment-methods/creditcard.svg', method.image['svg']
     end
 
+    def test_all_available
+      stub_request(:get, 'https://api.mollie.com/v2/methods/all')
+        .to_return(status: 200, body: read_fixture('methods/all.json'), headers: {})
+
+      available_methods = Method.all_available
+      assert_equal 3, available_methods.size
+
+      ideal_method = available_methods.first
+      assert_equal "pending-boarding", ideal_method.status
+    end
+
     def test_pricing
       stub_request(:get, 'https://api.mollie.com/v2/methods/creditcard?include=pricing')
         .to_return(status: 200, body: read_fixture('methods/get-includes-pricing.json'), headers: {})


### PR DESCRIPTION
Returns all payment methods that Mollie offers and can be activated by
the Organization.

Resolves #146, resolves #149