### PR TITLE
Ensure base get always receives an ID

### DIFF
--- a/lib/mollie/base.rb
+++ b/lib/mollie/base.rb
@@ -30,6 +30,8 @@ module Mollie
       end
 
       def get(id, options = {})
+        raise ArgumentError, 'id cannot be blank' if !id || id.to_s.strip.empty?
+
         request('GET', id, {}, options) do |response|
           new(response)
         end

--- a/lib/mollie/base.rb
+++ b/lib/mollie/base.rb
@@ -30,7 +30,7 @@ module Mollie
       end
 
       def get(id, options = {})
-        raise ArgumentError, 'id cannot be blank' if !id || id.to_s.strip.empty?
+        raise Mollie::Exception, "Invalid resource ID: #{id.inspect}" if id.nil? || id.strip.empty?
 
         request('GET', id, {}, options) do |response|
           new(response)

--- a/test/mollie/base_test.rb
+++ b/test/mollie/base_test.rb
@@ -44,10 +44,12 @@ module Mollie
       assert_equal 'my-id', resource.id
       assert_equal 'object-id', resource.testobject_id
     end
-
-    def test_get_without_id
-      assert_raises(ArgumentError) { TestObject.get(nil) }
-      assert_raises(ArgumentError) { TestObject.get(' ') }
+    def test_get_with_invalid_identifiers
+      assert_raises(Mollie::Exception) { TestObject.get(nil) }
+      assert_raises(Mollie::Exception) { TestObject.get(" ") }
+      assert_raises(Mollie::Exception) { TestObject.get("   ") }
+      assert_raises(Mollie::Exception) { TestObject.get("\t") }
+      assert_raises(Mollie::Exception) { TestObject.get("\n") }
     end
 
     def test_create

--- a/test/mollie/base_test.rb
+++ b/test/mollie/base_test.rb
@@ -45,6 +45,11 @@ module Mollie
       assert_equal 'object-id', resource.testobject_id
     end
 
+    def test_get_without_id
+      assert_raises(ArgumentError) { TestObject.get(nil) }
+      assert_raises(ArgumentError) { TestObject.get(' ') }
+    end
+
     def test_create
       stub_request(:post, 'https://api.mollie.com/v2/testobjects')
         .with(body: %({"foo":1.95}))


### PR DESCRIPTION
Yesterday, there was a major disruption in mollie. I found out that some payments were created, but we didn't get a response back. Later on, we did get a webhook calllback though. 

The issue we encountered is that when you do a `get` without an ID, you get a collection of payments as a response. This cannot be mapped to the object (Payment), but yields an 'empty' Payment object anyway. However, this also means that if you call `chargebacks` on that object, that you receive a collection of all available chargebacks for the account. This had some unfortunate consequences for us :)