### PR TITLE
Add changelog_uri to gemspec

### DIFF
--- a/mollie-api-ruby.gemspec
+++ b/mollie-api-ruby.gemspec
@@ -16,6 +16,10 @@ Gem::Specification.new do |s|
   s.email = ['info@mollie.com']
   s.homepage = 'https://github.com/mollie/mollie-api-ruby'
   s.license = 'BSD'
+  s.metadata = {
+    'changelog_uri' => 'https://github.com/mollie/mollie-api-ruby/blob/master/CHANGELOG.md'
+  }
+
   s.required_ruby_version = '>= 2.3.8'
 
   s.files = `git ls-files`.split("\n")


### PR DESCRIPTION
Supported here: https://guides.rubygems.org/specification-reference/#metadata Useful for running https://github.com/MaximeD/gem_updater