### PR TITLE
IMP-610: Use correct authorize URL

### DIFF
--- a/examples/connect/authorize.rb
+++ b/examples/connect/authorize.rb
@@ -5,7 +5,7 @@ client = Rack::OAuth2::Client.new(
   secret:                 secret,
   state:                  'some_state',
   redirect_uri:           redirect_url,
-  authorization_endpoint: 'https://www.mollie.com/oauth2/authorize',
+  authorization_endpoint: 'https://my.mollie.com/oauth2/authorize',
   token_endpoint:         'https://api.mollie.com/oauth2/tokens'
 )
 

--- a/examples/connect/tokens.rb
+++ b/examples/connect/tokens.rb
@@ -5,7 +5,7 @@ client = Rack::OAuth2::Client.new(
   secret:                 secret,
   state:                  'some_state',
   redirect_uri:           redirect_url,
-  authorization_endpoint: 'https://www.mollie.com/oauth2/authorize',
+  authorization_endpoint: 'https://my.mollie.com/oauth2/authorize',
   token_endpoint:         'https://api.mollie.com/oauth2/tokens'
 )
 


### PR DESCRIPTION
The authorize URL changed from www.mollie.com to my.mollie.com. This is to reflect this change.