### PR TITLE
Update README to reflect that all recent gems are available through RubyGems

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ To use the Mollie API client, the following things are required:
 
 ## Installation
 
-By far the easiest way to install the Mollie API client is to install it with [gem](http://rubygems.org/). Note: v4.8.0 and higher are not published on rubygems.org, see [GH-140](https://github.com/mollie/mollie-api-ruby/issues/140) for details.
+By far the easiest way to install the Mollie API client is to install it with [gem](http://rubygems.org/).
 
 ```
 # Gemfile
-gem "mollie-api-ruby", github: "mollie/mollie-api-ruby", tag: "v4.11.0"
+gem "mollie-api-ruby"
 
 $ gem install mollie-api-ruby
 ```


### PR DESCRIPTION
The issue has been resolved, and all gem releases are now available on RubyGems. To avoid misleading new users, we should remove this paragraph from the README and update the code sample accordingly.