### PR TITLE
Catch invalid JSON response and raise Mollie::RequestError

### DIFF
--- a/lib/mollie/client.rb
+++ b/lib/mollie/client.rb
@@ -133,7 +133,7 @@ module Mollie
         exception = ResourceNotFoundError.new(json, response)
         raise exception
       else
-        json = JSON.parse(response.body)
+        json = parse_body(response)
         exception = Mollie::RequestError.new(json, response)
         raise exception
       end
@@ -161,6 +161,16 @@ module Mollie
 
     def escape(s)
       URI.encode_www_form_component(s)
+    end
+
+    def parse_body(response)
+      JSON.parse(response.body)
+    rescue JSON::ParserError => e
+      {
+        "status" => response.code.to_i,
+        "title" => response.message,
+        "detail" => "Unable to parse JSON: #{e.message}"
+      }
     end
   end
 end

--- a/test/mollie/client_test.rb
+++ b/test/mollie/client_test.rb
@@ -179,25 +179,16 @@ module Mollie
     end
 
     def test_invalid_response
-      response = <<-JSON
-      {
-        "status": 500,
-        "title": "Internal server error",
-        "detail": "Unable to parse JSON: 859: unexpected token at '<h1>Internal server error</h1>'"
-      }
-      JSON
-
-      json = JSON.parse(response)
       stub_request(:post, 'https://api.mollie.com/v2/my-method')
         .to_return(status: [500, "Internal server error"], body: "<h1>Internal server error</h1>", headers: {})
 
-      e = assert_raise Mollie::RequestError.new(JSON.parse(response)) do
+      e = assert_raise Mollie::RequestError do
         client.perform_http_call('POST', 'my-method', nil, {})
       end
 
-      assert_equal(json['status'], e.status)
-      assert_equal(json['title'],  e.title)
-      assert_equal(json['detail'], e.detail)
+      assert_equal(500, e.status)
+      assert_equal('Internal server error', e.title)
+      assert_match(/Unable to parse JSON:.*/, e.detail)
     end
   end
 end

--- a/test/mollie/client_test.rb
+++ b/test/mollie/client_test.rb
@@ -177,5 +177,27 @@ module Mollie
       assert_equal(json['field'],  e.field)
       assert_equal(json['_links'], e.links)
     end
+
+    def test_invalid_response
+      response = <<-JSON
+      {
+        "status": 500,
+        "title": "Internal server error",
+        "detail": "Unable to parse JSON: 859: unexpected token at '<h1>Internal server error</h1>'"
+      }
+      JSON
+
+      json = JSON.parse(response)
+      stub_request(:post, 'https://api.mollie.com/v2/my-method')
+        .to_return(status: [500, "Internal server error"], body: "<h1>Internal server error</h1>", headers: {})
+
+      e = assert_raise Mollie::RequestError.new(JSON.parse(response)) do
+        client.perform_http_call('POST', 'my-method', nil, {})
+      end
+
+      assert_equal(json['status'], e.status)
+      assert_equal(json['title'],  e.title)
+      assert_equal(json['detail'], e.detail)
+    end
   end
 end


### PR DESCRIPTION
This PR tries to handle invalid JSON responses (for e.g. 500 / 503 errors with HTML body) and raise a `Mollie::RequestError` instead.

Occasionally, we see these errors in our logs, and it would be nice to be able to handle this in a clean way.
We are already handling `Mollie::RequestError` in our application and I think it makes sense to raise that error for this scenario too.

Must admit that it's an edge case, but it would still be nice to handle it like this and it would make our logs cleaner as well.