### PR TITLE
Avoid frozen string literals warnings with Ruby 3.4

### DIFF
--- a/lib/mollie/client.rb
+++ b/lib/mollie/client.rb
@@ -50,8 +50,8 @@ module Mollie
       @api_key         = api_key
       @version_strings = []
 
-      add_version_string 'Mollie/' << VERSION
-      add_version_string 'Ruby/' << RUBY_VERSION
+      add_version_string "Mollie/#{VERSION}"
+      add_version_string "Ruby/#{RUBY_VERSION}"
       add_version_string OpenSSL::OPENSSL_VERSION.split(' ').slice(0, 2).join '/'
     end
 


### PR DESCRIPTION
Strings are not frozen, so we get these wanrings when running our test suite:

```
ruby/gems/3.4.0/gems/mollie-api-ruby-4.15.0/lib/mollie/client.rb:54: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)

ruby/gems/3.4.0/gems/mollie-api-ruby-4.15.0/lib/mollie/client.rb:53: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
```