### PR TITLE
Add support for embedded refunds in payment object

### DIFF
--- a/lib/mollie/payment.rb
+++ b/lib/mollie/payment.rb
@@ -197,7 +197,13 @@ module Mollie
     end
 
     def refunds(options = {})
-      Payment::Refund.all(options.merge(payment_id: id))
+      resources = (attributes['_embedded']['refunds'] if attributes['_embedded'])
+
+      if resources.nil?
+        Payment::Refund.all(options.merge(payment_id: id))
+      else
+        List.new({ '_embedded' => { 'refunds' => resources } }, Payment::Refund)
+      end
     end
 
     def chargebacks(options = {})

--- a/test/fixtures/payments/get_embedded_resources.json
+++ b/test/fixtures/payments/get_embedded_resources.json
@@ -1,0 +1,74 @@
+{
+  "resource": "payment",
+  "id": "tr_WDqYK6vllg",
+  "mode": "test",
+  "createdAt": "2018-03-20T13:13:37+00:00",
+  "amount": {
+    "value": "10.00",
+    "currency": "EUR"
+  },
+  "description": "Order #12345",
+  "method": null,
+  "metadata": {
+    "order_id": "12345"
+  },
+  "status": "open",
+  "isCancelable": false,
+  "locale": "nl_NL",
+  "restrictPaymentMethodsToCountry": "NL",
+  "expiresAt": "2018-03-20T13:28:37+00:00",
+  "details": null,
+  "profileId": "pfl_QkEhN94Ba",
+  "sequenceType": "oneoff",
+  "redirectUrl": "https://webshop.example.org/order/12345/",
+  "webhookUrl": "https://webshop.example.org/payments/webhook/",
+  "_embedded": {
+    "refunds": [
+      {
+        "resource": "refund",
+        "id": "re_vD3Jm32wQt",
+        "amount": {
+          "value": "329.99",
+          "currency": "EUR"
+        },
+        "status": "pending",
+        "createdAt": "2019-01-15T15:41:21+00:00",
+        "description": "Required quantity not in stock, refunding one photo book.",
+        "orderId": "ord_kEn1PlbGa",
+        "paymentId": "tr_WDqYK6vllg",
+        "settlementAmount": {
+          "value": "-329.99",
+          "currency": "EUR"
+        },
+        "_links": {
+          "self": {
+            "href": "https://api.mollie.com/v2/payments/tr_WDqYK6vllg/refunds/re_vD3Jm32wQt",
+            "type": "application/hal+json"
+          },
+          "payment": {
+            "href": "https://api.mollie.com/v2/payments/tr_WDqYK6vllg",
+            "type": "application/hal+json"
+          },
+          "order": {
+            "href": "https://api.mollie.com/v2/orders/ord_kEn1PlbGa",
+            "type": "application/hal+json"
+          }
+        }
+      }
+    ]
+  },
+  "_links": {
+    "self": {
+      "href": "https://api.mollie.com/v2/payments/tr_WDqYK6vllg",
+      "type": "application/hal+json"
+    },
+    "checkout": {
+      "href": "https://www.mollie.com/payscreen/select-method/WDqYK6vllg",
+      "type": "text/html"
+    },
+    "documentation": {
+      "href": "https://docs.mollie.com/reference/v2/payments-api/get-payment",
+      "type": "text/html"
+    }
+  }
+}

--- a/test/mollie/payment_test.rb
+++ b/test/mollie/payment_test.rb
@@ -2,6 +2,8 @@ require 'helper'
 
 module Mollie
   class PaymentTest < Test::Unit::TestCase
+    GET_PAYMENT_WITH_EMBEDDED_RESOURCES = read_fixture('payments/get_embedded_resources.json')
+
     def test_setting_attributes
       attributes = {
         resource:   'payment',
@@ -231,6 +233,16 @@ module Mollie
 
       payment = Payment.get('tr_WDqYK6vllg')
       assert_equal 'NL', payment.restrict_payment_methods_to_country
+    end
+
+    def test_embedded_refunds
+      stub_request(:get, 'https://api.mollie.com/v2/payments/tr_WDqYK6vllg')
+        .to_return(status: 200, body: GET_PAYMENT_WITH_EMBEDDED_RESOURCES, headers: {})
+
+      payment = Payment.get('tr_WDqYK6vllg')
+
+      assert_equal 're_vD3Jm32wQt', payment.refunds.first.id
+      assert_equal 1, payment.refunds.size
     end
 
     def test_list_refunds


### PR DESCRIPTION
In the API it's possible to embed refunds, so it's not necessary to do another request for them. In this PR I'm adding support for using this embedded refunds when doing something like `payment.refunds`.

The same needs to be done for chargebacks and captures. Maybe someone can help with adding those resources to `test/fixtures/payments/get_embedded_resources.json`